### PR TITLE
Tweaks for Autumn

### DIFF
--- a/autumn/autumn.prytheme
+++ b/autumn/autumn.prytheme
@@ -4,16 +4,17 @@ meta:
   version     : 2
   color-depth : 256
   description : Inspired by the colors you can find in the autumn
-  author      : Kyrylo Silin <kyrylosilin@gmail.com>
+  author      : Kyrylo Silin <kyrylosilin@gmail.com>,
+                Yorick Peterse <yorickpeterse@gmail.com>
 
 theme:
   class               : (d)
   class_variable      : bluish02
   comment             : wet_asphalt07
   constant            : lemon_cream
-  error               : white (i)
+  error               : lemon_cream on chestnut01
   float               : dark_tea_green
-  global_variable     : bluish02
+  global_variable     : lemon_cream
   instance_variable   : bluish02
   integer             : dark_tea_green
   keyword             : chestnut01


### PR DESCRIPTION
A few small changes have been made to the Autumn theme. Global variables should
be displayed in the same color as local variables. Errors use the default color
on a red background (instead of black on white).

I've also updated the list of theme authors so that the Pry theme honors the
Creative Commons license that I've used for Autumn.
